### PR TITLE
feat: read a concert

### DIFF
--- a/concertcapsule/urls.py
+++ b/concertcapsule/urls.py
@@ -16,7 +16,16 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from django.conf.urls import include
+from rest_framework import routers
+from concertcapsuleapi.views import VenueView, ArtistView, ConcertView
+
+router = routers.DefaultRouter(trailing_slash=False)
+router.register(r'venues', VenueView, 'venue')
+router.register(r'artists', ArtistView, 'artist')
+router.register(r'concerts', ConcertView, 'concert')
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', include(router.urls)),
 ]

--- a/concertcapsuleapi/models/artist_concert.py
+++ b/concertcapsuleapi/models/artist_concert.py
@@ -9,6 +9,6 @@ from .concert import Concert
 
 
 class ArtistConcert(models.Model):
-    """Represents an instance of a user attending a concert, AKA a ticket"""
-    artist_id = models.ForeignKey(Artist, on_delete=models.CASCADE)
-    concert_id = models.ForeignKey(Concert, on_delete=models.CASCADE)
+    """Represents an instance of an artist performing at a concert"""
+    artist = models.ForeignKey(Artist, on_delete=models.CASCADE)
+    concert = models.ForeignKey(Concert, on_delete=models.CASCADE)

--- a/concertcapsuleapi/models/concert.py
+++ b/concertcapsuleapi/models/concert.py
@@ -2,7 +2,7 @@
     concert.py
 
     Defines the Django model for a concert, including:
-    artist id, venue id, tour name, date and time
+    venue id, date and uid
     """
 from django.db import models
 from .venue import Venue
@@ -10,5 +10,6 @@ from .venue import Venue
 
 class Concert(models.Model):
     """Represents a concert in the database"""
-    venue_id = models.ForeignKey(Venue, on_delete=models.SET_NULL, null=True)
-    date = models.DateField()
+    venue = models.ForeignKey(Venue, on_delete=models.SET_NULL, null=True)
+    date = models.CharField(max_length=50)
+    uid = models.CharField(max_length=50)

--- a/concertcapsuleapi/views/concert.py
+++ b/concertcapsuleapi/views/concert.py
@@ -1,0 +1,120 @@
+"""View module for handling requests about concerts"""
+from django.http import HttpResponseServerError
+import traceback
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from concertcapsuleapi.models import Concert, Venue, ArtistConcert, Artist
+
+
+class ConcertView(ViewSet):
+    """Concerts View"""
+
+    def retrieve(self, request, pk):
+        """GET a single concert"""
+        try:
+            concert = Concert.objects.get(pk=pk)
+            serializer = ConcertSerializer(concert)
+            return Response(serializer.data)
+        except Concert.DoesNotExist:
+            return Response({"error": "Concert not found"}, status=status.HTTP_404_NOT_FOUND)
+
+    def list(self, request):
+        """GET all concerts"""
+        uid = request.query_params.get("uid", None)
+
+        if uid:
+            concerts = Concert.objects.filter(uid=uid)
+        else:
+            concerts = Concert.objects.all()
+        serializer = ConcertSerializer(concerts, many=True)
+        return Response(serializer.data)
+
+    def destroy(self, request, pk):
+        """DELETE a concert"""
+        try:
+            concert = Concert.objects.get(pk=pk)
+            concert.delete()
+            return Response(None, status=status.HTTP_204_NO_CONTENT)
+        except Concert.DoesNotExist:
+            return Response({"error": "Concert not found"}, status=status.HTTP_404_NOT_FOUND)
+
+    def update(self, request, pk):
+        """Handle PUT requests to update an existing concert"""
+        try:
+            concert = Concert.objects.get(pk=pk)
+            venue = Venue.objects.get(pk=request.data["venue"])
+
+            # Update fields
+            concert.uid = request.data["uid"]
+            concert.venue_id = venue.id
+            concert.date = request.data["date"]
+
+            # Update artists in the join table
+            artist_ids = request.data.get("artists", [])
+            # Remove existing artist associations
+            ArtistConcert.objects.filter(concert=concert).delete()
+            # Add new artist associations
+            for artist_id in artist_ids:
+                artist = Artist.objects.get(pk=artist_id)
+                ArtistConcert.objects.create(
+                    concert_id=concert.id,
+                    artist_id=artist.id
+                )
+
+            concert.save()
+            serializer = ConcertSerializer(concert)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except Concert.DoesNotExist:
+            return Response({'message': 'Concert not found'}, status=status.HTTP_404_NOT_FOUND)
+
+    def create(self, request):
+        """POST a new concert"""
+        try:
+            # Fetch related venue
+            venue = Venue.objects.get(pk=request.data["venue"])
+            # Create Concert
+            concert = Concert.objects.create(
+                venue_id=venue.id,
+                uid=request.data["uid"],
+                date=request.data["date"],
+            )
+
+            # Link artists via join table
+            artist_ids = request.data.get("artists", [])
+            for artist_id in artist_ids:
+                artist = Artist.objects.get(pk=artist_id)
+                ArtistConcert.objects.create(
+                    concert_id=concert.id,
+                    artist_id=artist.id
+                )
+
+            serializer = ConcertSerializer(concert)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        except Venue.DoesNotExist:
+            return Response({"error": "Venue not found"}, status=status.HTTP_400_BAD_REQUEST)
+        except Artist.DoesNotExist:
+            return Response({"error": "Artist not found"}, status=status.HTTP_400_BAD_REQUEST)
+        except Exception as e:
+            traceback.print_exc()
+            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+
+class ArtistSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Artist
+        fields = ['id', 'name']
+
+
+class ConcertSerializer(serializers.ModelSerializer):
+    artists = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Concert
+        fields = ('id', 'date', 'venue', 'artists')
+        depth = 1
+
+    def get_artists(self, concert):
+        artist_concerts = ArtistConcert.objects.filter(concert=concert)
+        artists = [ac.artist for ac in artist_concerts]
+        return ArtistSerializer(artists, many=True).data


### PR DESCRIPTION
### Changes
- **API Routing**
  - Registered new `ConcertView` in `urls.py` using DRF router (`/concerts`).

- **Models**
  - Updated `Concert` model:
    - Renamed `venue_id` → `venue` (FK to `Venue`).
    - Changed `date` field from `DateField` → `CharField(max_length=50)`.
    - Added `uid` field.
  - Updated `ArtistConcert` model:
    - Renamed `artist_id` → `artist`.
    - Renamed `concert_id` → `concert`.
    - Updated docstring to clarify it represents **artist performing at a concert**.

- **Views**
  - Added new `ConcertView` (DRF `ViewSet`) with full CRUD support:
    - `retrieve` → Get a single concert.
    - `list` → Get all concerts (with optional `uid` filter).
    - `create` → Add new concert with venue + artists.
    - `update` → Update concert details and reset artist associations.
    - `destroy` → Delete a concert.
  - Implemented error handling (`Concert`, `Venue`, and `Artist` not found).
  - Added serializer logic:
    - `ConcertSerializer` includes nested `venue` and list of `artists`.
    - `ArtistSerializer` defined for embedding artist info.
